### PR TITLE
Added windows support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-    id "org.jetbrains.intellij" version "0.4.1"
+    id "org.jetbrains.intellij" version "0.4.2"
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 # Available IntelliJ IDEA versions:
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
-myPluginVersion=1.1.3
-intellijPlatformVersion=2019.2
+myPluginVersion=1.1.6
+intellijPlatformVersion=2019.3
 
 javaVersion = 1.8
 javaTargetVersion = 1.8

--- a/src/main/kotlin/tlint/inspection/TLintExternalAnnotator.kt
+++ b/src/main/kotlin/tlint/inspection/TLintExternalAnnotator.kt
@@ -109,8 +109,9 @@ class TLintExternalAnnotator : ExternalAnnotator<ExternalLintAnnotationInput, Ex
         @Throws(Exception::class)
         private fun getTlintExecutablePath(cwd: String): String {
             val lintExecutable: File
-            val localTlintExecutable = File("$cwd/vendor/bin/tlint")
-            val globalTlintExecutable = File(System.getProperty("user.home") + "/.composer/vendor/bin/tlint")
+            val osExtension = if (this.isWindows()!!) ".bat" else ""
+            val localTlintExecutable = File("$cwd/vendor/bin/tlint$osExtension")
+            val globalTlintExecutable = File(System.getProperty("user.home") + "/.composer/vendor/bin/tlint"+osExtension)
 
             lintExecutable = when {
                 globalTlintExecutable.exists() -> globalTlintExecutable
@@ -121,6 +122,14 @@ class TLintExternalAnnotator : ExternalAnnotator<ExternalLintAnnotationInput, Ex
             }
 
             return lintExecutable.absolutePath
+        }
+
+        private fun getOsName(): String? {
+            return System.getProperty("os.name")
+        }
+
+        private fun isWindows(): Boolean? {
+            return this.getOsName()?.startsWith("Windows")
         }
 
         private fun createAnnotation(


### PR DESCRIPTION
I have made a little change in order to support .bat on windows.

The fail that plugin returned on the microsoft system was:

`TLint plugin: com.intellij.execution.process.ProcessNotCreatedException: Cannot run program "C:\project\vendor\bin\tlint"`